### PR TITLE
Update nightly sanity target to _sanity.regular

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -27,4 +27,4 @@ jobs:
         version: ${{ matrix.version }}
         jdksource: 'install-jdk'
         build_list: ${{ matrix.buildlist}}
-        target: '_sanity'
+        target: '_sanity.regular'


### PR DESCRIPTION
Nightly run against AdoptOpenJDK nightly builds grabbed AdoptOpenJDK
API, which doesn't include testimages or test on native libs. This
change will stop running test labeled  as 'native'

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>