### PR TITLE
Add openjdk_testRepo parameter.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
   custom_target:   #  Used if need to set non-default custom target
     description:
     required: false
+  Openjdk_testPRorPush:
+    description: 'A boolean value ("true" or "false") on whether the this is a PR|Push build'
+    required: false
+    default: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -17,10 +17,10 @@ inputs:
   custom_target:   #  Used if need to set non-default custom target
     description:
     required: false
-  Openjdk_testPRorPush:
-    description: 'A boolean value ("true" or "false") on whether the this is a PR|Push build'
+  openjdk_testRepo:
+    description: 'openjdk Repo'
     required: false
-    default: false
+    default: 'openjdk-tests:master'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/aqa.ts
+++ b/src/aqa.ts
@@ -8,6 +8,7 @@ async function run(): Promise<void> {
     const buildList = core.getInput('build_list', {required: false})
     const target = core.getInput('target', {required: false})
     const customTarget = core.getInput('custom_target',{required: false})
+    const openjdktestPRorPush = core.getInput('Openjdk_testPRorPush') === 'true'
     //  let arch = core.getInput("architecture", { required: false })
     if (
       jdksource !== 'upstream' &&
@@ -36,7 +37,7 @@ async function run(): Promise<void> {
       )
     }
 
-    await runaqa.runaqaTest(version, jdksource, buildList, target, customTarget)
+    await runaqa.runaqaTest(version, jdksource, buildList, target, customTarget, openjdktestPRorPush)
   } catch (error) {
     core.setFailed(error.message)
   }

--- a/src/aqa.ts
+++ b/src/aqa.ts
@@ -7,8 +7,9 @@ async function run(): Promise<void> {
     const version = core.getInput('version', {required: false})
     const buildList = core.getInput('build_list', {required: false})
     const target = core.getInput('target', {required: false})
-    const customTarget = core.getInput('custom_target',{required: false})
-    const openjdktestPRorPush = core.getInput('Openjdk_testPRorPush') === 'true'
+    const customTarget = core.getInput('custom_target', {required: false})
+    const openjdktestRepo = core.getInput('openjdk_testRepo', {required: false})
+
     //  let arch = core.getInput("architecture", { required: false })
     if (
       jdksource !== 'upstream' &&
@@ -37,7 +38,7 @@ async function run(): Promise<void> {
       )
     }
 
-    await runaqa.runaqaTest(version, jdksource, buildList, target, customTarget, openjdktestPRorPush)
+    await runaqa.runaqaTest(version, jdksource, buildList, target, customTarget, openjdktestRepo)
   } catch (error) {
     core.setFailed(error.message)
   }

--- a/src/runaqa.ts
+++ b/src/runaqa.ts
@@ -30,16 +30,18 @@ export async function runaqaTest(
   jdksource: string,
   buildList: string,
   target: string,
-  customTarget: string
+  customTarget: string,
+  openjdktestPRorPush: boolean
 ): Promise<void> {
   await installDependency()
   process.env.BUILD_LIST = buildList
   if (!('TEST_JDK_HOME' in process.env)) process.env.TEST_JDK_HOME = getTestJdkHome(version, jdksource)
-  await exec.exec(
-    'git clone --depth 1 https://github.com/AdoptOpenJDK/openjdk-tests.git'
-  )
-  process.chdir('openjdk-tests')
-  await exec.exec('ls')
+  if (!openjdktestPRorPush) {
+    await exec.exec(
+      'git clone --depth 1 https://github.com/AdoptOpenJDK/openjdk-tests.git'
+    )
+    process.chdir('openjdk-tests')
+  }
   if (IS_WINDOWS) {
     await exec.exec('bash ./get.sh')
   } else {
@@ -112,3 +114,17 @@ async function installDependency(): Promise<void> {
     await exec.exec('sudo apt-get install ant-contrib -y')
   }
 }
+
+/* async function getOpenjdkTestRepo(openjdktestRepo: string): Promise<void> {
+  let repo = 'AdoptOpenJDK/openjdk-tests'
+  let branch = 'master'
+  if (openjdktestRepo !== 'AdoptOpenJDK:master') {
+    repo = process.env.GITHUB_REPOSITORY as string
+    const ref = process.env.GITHUB_REF as string
+    branch = ref.substr(ref.lastIndexOf('/') + 1)
+  }
+  await exec.exec(
+    `git clone --depth 1 -b ${branch} https://github.com/${repo}.git`
+  )
+}
+ */


### PR DESCRIPTION
User can specify preferred openjdk_testRepo, which also works for PR or Push event.
Also add the check if workspace already have the openjdk-tests cloned to avoid re-clone.


Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>