### PR TITLE
disable apport

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3464,12 +3464,15 @@ function installDependencyAndSetup() {
         else {
             yield exec.exec('sudo apt-get update');
             yield exec.exec('sudo apt-get install ant-contrib -y');
+            //environment
             if ('RUNNER_USER' in process.env) {
                 process.env['LOGNAME'] = process.env['RUNNER_USER'];
             }
             else {
                 core.warning('RUNNER_USER is not the GitHub Actions environment variables shell script. Container is configured differently. Please check the updated lists of environment variables.');
             }
+            //disable apport
+            yield exec.exec('sudo service apport stop');
         }
     });
 }

--- a/src/runaqa.ts
+++ b/src/runaqa.ts
@@ -115,11 +115,15 @@ async function installDependencyAndSetup(): Promise<void> {
   } else {
     await exec.exec('sudo apt-get update')
     await exec.exec('sudo apt-get install ant-contrib -y')
+    //environment
     if ('RUNNER_USER' in process.env) {
       process.env['LOGNAME'] = process.env['RUNNER_USER']
     } else {
       core.warning('RUNNER_USER is not the GitHub Actions environment variables shell script. Container is configured differently. Please check the updated lists of environment variables.')
     }
+
+    //disable apport
+    await exec.exec('sudo service apport stop')
   }
 }
 


### PR DESCRIPTION
The tool might interfere with the VM's system dump file processing by renaming or truncating system dumps. Disable it for testing.

Related #50 

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>