### PR TITLE
Using latest version to run nightly

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -15,7 +15,7 @@ jobs:
         buildlist: [openjdk, system, functional]
     steps:
     - uses: actions/checkout@v1
-    - uses: AdoptOpenJDK/install-jdk@v1
+    - uses: ./
       with:
         version: ${{ matrix.version }}
         targets: JDK_${{ matrix.version }}


### PR DESCRIPTION
Use latest to run nightly sanity tests.

This way we don't need to release a new version whenever there is update or fix and keep the build running against latest. Will release only when there are new features 


Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>