### PR TITLE
Remove check if openjdk-tests/openjdk-tests directory available

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3381,10 +3381,7 @@ function runaqaTest(version, jdksource, buildList, target, customTarget, openjdk
         process.env.BUILD_LIST = buildList;
         if (!('TEST_JDK_HOME' in process.env))
             process.env.TEST_JDK_HOME = getTestJdkHome(version, jdksource);
-        const workspace = process.env['GITHUB_WORKSPACE'] || '';
-        if (!(workspace.includes('/openjdk-tests/openjdk-tests') || workspace.includes('\openjdk-tests\openjdk-tests'))) {
-            yield getOpenjdkTestRepo(openjdktestRepo);
-        }
+        yield getOpenjdkTestRepo(openjdktestRepo);
         yield runGetSh(tkgRepo);
         const options = {};
         let myOutput = '';

--- a/src/runaqa.ts
+++ b/src/runaqa.ts
@@ -37,11 +37,8 @@ export async function runaqaTest(
   setSpec()
   process.env.BUILD_LIST = buildList
   if (!('TEST_JDK_HOME' in process.env)) process.env.TEST_JDK_HOME = getTestJdkHome(version, jdksource)
-  const workspace = process.env['GITHUB_WORKSPACE'] || ''
-  if (!(workspace.includes('/openjdk-tests/openjdk-tests') || workspace.includes('\openjdk-tests\openjdk-tests'))) {
-    await getOpenjdkTestRepo(openjdktestRepo)
-  }
 
+  await getOpenjdkTestRepo(openjdktestRepo)
   await runGetSh(tkgRepo)
 
   const options: ExecOptions = {}


### PR DESCRIPTION
The check is to avoid re-git clone openjdk-tests repo if the openjdk-tests directory exists. However it happens the exist repo is not the one run-aqa expected. 

Remove it and use `openjdk_testRepo` specifically to git clone expected repo.

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>